### PR TITLE
Don't set the include flag.

### DIFF
--- a/node18-esm.json
+++ b/node18-esm.json
@@ -24,6 +24,5 @@
 		"checkJs": true,
 		"outDir": "dist",
 		"allowSyntheticDefaultImports": true
-	},
-	"include": ["src"]
+	}
 }


### PR DESCRIPTION
Caused an error in use:

```
error TS18003: No inputs were found in config file '/Users/rijkvanzanten/Developer/directus/directus/packages/storage/tsconfig.json'. Specified 'include' paths were '["node_modules/@directus/tsconfig/src"]' and 'exclude' paths were '[]'.
```