### PR TITLE
Don't set options that use paths

### DIFF
--- a/node18-esm.json
+++ b/node18-esm.json
@@ -22,9 +22,9 @@
 		"noUnusedParameters": true,
 		"importsNotUsedAsValues": "error",
 		"checkJs": true,
-		"outDir": "../../dist",
+		"outDir": "../../../dist",
 		"allowSyntheticDefaultImports": true
 	},
-	"include": ["../../src"],
-	"exclude": ["../../node_modules", "../../dist"]
+	"include": ["../../../src"],
+	"exclude": ["../../../node_modules", "../../../dist"]
 }

--- a/node18-esm.json
+++ b/node18-esm.json
@@ -22,7 +22,9 @@
 		"noUnusedParameters": true,
 		"importsNotUsedAsValues": "error",
 		"checkJs": true,
-		"outDir": "dist",
+		"outDir": "../../dist",
 		"allowSyntheticDefaultImports": true
-	}
+	},
+	"include": ["../../src"],
+	"exclude": ["../../node_modules", "../../dist"]
 }

--- a/node18-esm.json
+++ b/node18-esm.json
@@ -22,9 +22,6 @@
 		"noUnusedParameters": true,
 		"importsNotUsedAsValues": "error",
 		"checkJs": true,
-		"outDir": "../../../dist",
 		"allowSyntheticDefaultImports": true
-	},
-	"include": ["../../../src"],
-	"exclude": ["../../../node_modules", "../../../dist"]
+	}
 }


### PR DESCRIPTION
TS Config files are relative to the place where the actual source file lives, rather than the source of the root ts config file that imports the extended file. This in turn means that `outDir: 'dist'` would erroneously build to `node_modules/@directus/tsconfig/dist` 